### PR TITLE
Add bold monospace font to fix editor misalignment in Firefox

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -48,7 +48,7 @@ export default defineNuxtConfig({
 			"Roboto": [300, 400, 500, 700],
 			"Kreon": true,
 			"Itim": true,
-			"Fira+Mono": true,
+			"Fira+Mono": [400, 700],
 		},
 	},
 	typescript: {


### PR DESCRIPTION
Before this, only the normal weight version of the Fira Code font was being imported, causing the browser to extrapolate for the bold font used in text fields in syntax highlighting. Firefox uses an extrapolation algorithm which is easier on the eyes by spacing bold characters further from each other, but currently does not maintain constant character width for normal and bold weight characters when a non-system font without imported bold variant is used (as per https://github.com/WebCoder49/code-input/issues/130#issuecomment-3130052791). This caused the code-input editor to misalign editable and highlighted text of especially longer title fields, which this PR fixes.

An alternative would be using the system monospace font for the `code-input` component (fewer resources), but I have followed your convention of using Google Fonts.